### PR TITLE
[FIX] Remove nested forms breaking delete buttons

### DIFF
--- a/bps_internal_tools/static/ui.js
+++ b/bps_internal_tools/static/ui.js
@@ -56,3 +56,33 @@ document.addEventListener('change', (e)=>{
     }
   }
 });
+
+
+// Delete confimration tools... should probably go somewhere better...
+
+// Catch explicit clicks (still useful for older browsers / edge cases)
+document.addEventListener("click", function (e) {
+  const btn = e.target.closest(".confirm-delete");
+  if (!btn) return;
+
+  const label = btn.getAttribute("aria-label") || "this item";
+  if (!confirm(`Are you sure you want to delete ${label}? This cannot be undone.`)) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+});
+
+// Definitive guard: block form submission when the delete button is the submitter
+document.addEventListener("submit", function (e) {
+  // Modern browsers set e.submitter to the button that triggered submit
+  const submitter = e.submitter || document.activeElement;
+  if (!submitter) return;
+
+  if (submitter.classList && submitter.classList.contains("confirm-delete")) {
+    const label = submitter.getAttribute("aria-label") || "this item";
+    if (!confirm(`Are you sure you want to delete ${label}? This cannot be undone.`)) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  }
+}, true); // useCapture=true ensures we run before default handlers

--- a/bps_internal_tools/templates/admin_roles.html
+++ b/bps_internal_tools/templates/admin_roles.html
@@ -60,11 +60,20 @@
           <input type="checkbox" name="active" {% if r.active %}checked{% endif %}> Active
         </label>
 
-        <div style="display:flex;gap:8px;margin-top:10px;">
-          <button class="btn" type="submit" style="width:auto;">Save</button>
-          <form method="post" action="{{ url_for('admin.delete_role_route', role=r.role) }}" onsubmit="return confirm('Delete role {{r.role}}?')">
-            <button class="btn danger" type="submit" style="width:auto;">Delete</button>
-          </form>
+        <div class="row mt-10">
+          <button class="btn" type="submit">Save</button>
+
+          <!-- Delete submits to a different endpoint via formaction -->
+          <button
+            class="btn danger outline confirm-delete"
+            type="submit"
+            formmethod="post"
+            formaction="{{ url_for('admin.delete_role_route', role=r.role) }}"
+            formnovalidate
+            aria-label="Delete role {{ r.role }}"
+          >
+            Delete
+          </button>
         </div>
       </form>
     </div>

--- a/bps_internal_tools/templates/admin_users.html
+++ b/bps_internal_tools/templates/admin_users.html
@@ -24,31 +24,46 @@
   <h2 style="margin-top:0">Existing Users</h2>
   <div class="grid">
     {% for u in users %}
-    <div class="tile" style="flex-direction:column; align-items:stretch;">
-      <form method="post" action="{{ url_for('admin.update_user_route', username=u.username) }}">
-        <div><strong>{{ u.username }}</strong> {% if not u.active %}<span style="color:#ffa6a6;">(inactive)</span>{% endif %}</div>
-        <label style="margin-top:8px;">Display Name</label>
+    <div class="tile col">
+      <form method="post" action="{{ url_for('admin.update_user_route', username=u.username) }}" class="user-edit-form">
+        <div><strong>{{ u.username }}</strong> {% if not u.active %}<span class="text-warn">(inactive)</span>{% endif %}</div>
+
+        <label class="mt-8">Display Name</label>
         <input class="input" name="display_name" value="{{ u.display_name }}">
-        <label>Role</label>
+
+        <label class="mt-8">Role</label>
         <select class="input" name="role">
           {% for r in roles if r.active %}
           <option value="{{ r.role }}" {% if r.role == u.role %}selected{% endif %}>{{ r.role }}</option>
           {% endfor %}
         </select>
-        <label style="display:flex;align-items:center;gap:8px;margin-top:8px;">
+
+        <label class="mt-8 inline">
           <input type="checkbox" name="active" {% if u.active %}checked{% endif %}> Active
         </label>
-        <label>New Password (optional)</label>
+
+        <label class="mt-8">New Password (optional)</label>
         <input class="input" type="password" name="new_password" placeholder="Leave blank to keep existing">
-        <div style="display:flex;gap:8px;margin-top:10px;">
-          <button class="btn" type="submit" style="width:auto;">Save</button>
-          <form method="post" action="{{ url_for('admin.delete_user_route', username=u.username) }}" onsubmit="return confirm('Delete user {{u.username}}?')">
-            <button class="btn danger" type="submit" style="width:auto;">Delete</button>
-          </form>
+
+        <div class="row mt-10">
+          <button class="btn" type="submit">Save</button>
+
+          <!-- Delete submits to a different endpoint via formaction -->
+          <button
+            class="btn danger outline confirm-delete"
+            type="submit"
+            formmethod="post"
+            formaction="{{ url_for('admin.delete_user_route', username=u.username) }}"
+            formnovalidate
+            aria-label="Delete user {{ u.display_name }}"
+          >
+            Delete
+          </button>
         </div>
       </form>
     </div>
     {% endfor %}
+
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
### PR: Fix Delete Button Behavior on Users and Roles Pages

**Summary**
This PR fixes the issue where the "Delete" buttons on the Users and Roles settings pages were not working correctly. Previously, the delete button was nested inside the update form, causing it to incorrectly trigger the update action instead of the delete route.

**Changes Made**

* Refactored the template code to avoid nested `<form>` elements.
* Updated delete buttons to use `type="submit"` with `formmethod="post"` and `formaction` attributes, ensuring they target the correct delete routes.
* Added a **confirmation dialog** via JavaScript before executing any delete action:

  * Uses `e.submitter` in the `submit` event to reliably detect the button that triggered submission.
  * Ensures confirmation prompts work for both mouse clicks and keyboard submissions.
  * Prevents accidental deletions by requiring explicit confirmation.

**Result**

* Delete buttons now correctly call their respective delete routes.
* Confirmation dialog is consistently displayed before deletion.
* No nested forms remain in the template, making form handling cleaner and more reliable.

**Testing**

* Verified that user deletion works and updates the database.
* Verified that role deletion works as expected.
* Confirmed that "Save" (update) actions are unaffected.
* Confirmed confirmation prompt always appears before deletion.
