### PR TITLE
feat: import Canvas SIS CSVs into MariaDB

### DIFF
--- a/scripts/import_to_sqlite.py
+++ b/scripts/import_to_sqlite.py
@@ -1,87 +1,120 @@
-import sqlite3
+"""Import Canvas SIS export CSVs into the application's MariaDB database.
+
+This script replaces the old SQLite importer and now operates directly on the
+MariaDB schema used by the application.  It reads `courses.csv`,
+`users.csv`, and `enrollments.csv` from a directory and applies the changes to
+the database:
+
+* Rows with matching primary keys are **updated** – only the columns present in
+  the CSV are touched, so existing data in other columns remains intact.
+* Rows that exist in the database but not in the CSV are **removed**.
+* For `enrollments`, the table is replaced entirely with the contents of the
+  CSV (i.e. it mirrors the CSV exactly).
+
+Usage (from repository root)::
+
+    python -m scripts.import_to_sqlite --db <DB_URL> --dir env/sis_export
+
+The database URL defaults to the ``DATABASE_URL`` environment variable and the
+CSV directory defaults to ``env/sis_export``.
+"""
+
+import argparse
+import os
+from typing import Optional, Type
+
 import pandas as pd
+from sqlalchemy import create_engine, delete
+from sqlalchemy.orm import Session
 
-# File paths
-COURSES_CSV = '../env/sis_export/courses.csv'
-ENROLLMENTS_CSV = '../env/sis_export/enrollments.csv'
-USERS_CSV = '../env/sis_export/users.csv'
-DB_FILE = '../data/canvas.db'
+from bps_internal_tools.models import Base, Course, People, Enrollment
 
-# Connect to SQLite database (or create it)
-conn = sqlite3.connect(DB_FILE)
-cursor = conn.cursor()
 
-# Enable foreign key constraint support
-cursor.execute('PRAGMA foreign_keys = ON;')
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Import Canvas SIS CSV exports into MariaDB",
+    )
+    parser.add_argument(
+        "--db",
+        default=os.getenv("DATABASE_URL"),
+        help="SQLAlchemy database URL (defaults to DATABASE_URL env var)",
+    )
+    parser.add_argument(
+        "--dir",
+        default=os.getenv("SIS_EXPORT_DIR", "env/sis_export"),
+        help="Directory containing courses.csv, users.csv, enrollments.csv",
+    )
+    return parser.parse_args()
 
-# Drop tables if they already exist (for re-run purposes)
-cursor.execute('DROP TABLE IF EXISTS enrollments')
-cursor.execute('DROP TABLE IF EXISTS courses')
-cursor.execute('DROP TABLE IF EXISTS users')
 
-# Create tables
-cursor.execute('''
-CREATE TABLE users (
-    user_id TEXT PRIMARY KEY,
-    integration_id TEXT,
-    authentication_provider_id TEXT,
-    login_id TEXT,
-    password TEXT,
-    first_name TEXT,
-    last_name TEXT,
-    full_name TEXT,
-    sortable_name TEXT,
-    short_name TEXT,
-    email TEXT,
-    status TEXT,
-    pronouns TEXT
-)
-''')
+def load_csv(path: str) -> Optional[pd.DataFrame]:
+    """Load a CSV file into a DataFrame if it exists."""
+    if not os.path.exists(path):
+        print(f"⚠️  CSV not found: {path}")
+        return None
+    return pd.read_csv(path)
 
-cursor.execute('''
-CREATE TABLE courses (
-    course_id TEXT PRIMARY KEY,
-    integration_id TEXT,
-    short_name TEXT,
-    long_name TEXT,
-    account_id TEXT,
-    term_id TEXT,
-    status TEXT,
-    start_date TEXT,
-    end_date TEXT,
-    course_format TEXT,
-    blueprint_course_id TEXT
-)
-''')
 
-cursor.execute('''
-CREATE TABLE enrollments (
-    course_id TEXT,
-    user_id TEXT,
-    role TEXT,
-    role_id INTEGER,
-    section_id TEXT,
-    status TEXT,
-    associated_user_id TEXT,
-    limit_section_privileges TEXT,
-    temporary_enrollment_source_user_id TEXT,
-    FOREIGN KEY (user_id) REFERENCES users(user_id),
-    FOREIGN KEY (course_id) REFERENCES courses(course_id)
-)
-''')
+def upsert_from_df(session: Session, model: Type[Base], df: pd.DataFrame, pk: str) -> None:
+    """Upsert rows from *df* into *model* and remove missing rows."""
+    if df is None:
+        return
 
-# Load CSVs into pandas
-users_df = pd.read_csv(USERS_CSV)
-courses_df = pd.read_csv(COURSES_CSV)
-enrollments_df = pd.read_csv(ENROLLMENTS_CSV)
+    csv_ids = set()
+    for _, row in df.iterrows():
+        data = {k: (None if pd.isna(v) else v) for k, v in row.items()}
+        pk_val = data[pk]
+        csv_ids.add(pk_val)
+        obj = session.get(model, pk_val)
+        if obj:
+            for col, val in data.items():
+                setattr(obj, col, val)
+        else:
+            session.add(model(**data))
 
-# Write DataFrames to SQLite
-users_df.to_sql('users', conn, if_exists='append', index=False)
-courses_df.to_sql('courses', conn, if_exists='append', index=False)
-enrollments_df.to_sql('enrollments', conn, if_exists='append', index=False)
+    session.flush()
+    # Remove rows not present in the CSV
+    if csv_ids:
+        session.query(model).filter(~getattr(model, pk).in_(csv_ids)).delete(
+            synchronize_session=False
+        )
+    session.commit()
 
-# Commit and close
-conn.commit()
-conn.close()
 
-print("✅ Data successfully imported into canvas.db")
+def replace_enrollments(session: Session, df: pd.DataFrame) -> None:
+    """Replace the enrollments table contents with *df* (mirror CSV)."""
+    if df is None:
+        return
+
+    session.execute(delete(Enrollment))
+    rows = df.where(pd.notnull(df), None).to_dict(orient="records")
+    if rows:
+        session.bulk_insert_mappings(Enrollment, rows)
+    session.commit()
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.db:
+        raise SystemExit("❌ Provide a database URL via --db or DATABASE_URL env var")
+
+    engine = create_engine(args.db, future=True)
+    # Ensure tables exist (no-op if already present)
+    Base.metadata.create_all(engine)
+
+    csv_dir = args.dir
+    courses_df = load_csv(os.path.join(csv_dir, "courses.csv"))
+    users_df = load_csv(os.path.join(csv_dir, "users.csv"))
+    enrollments_df = load_csv(os.path.join(csv_dir, "enrollments.csv"))
+
+    with Session(engine) as session:
+        upsert_from_df(session, Course, courses_df, "course_id")
+        upsert_from_df(session, People, users_df, "user_id")
+        replace_enrollments(session, enrollments_df)
+
+    print("✅ Canvas SIS data imported")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- replace SQLite import script with MariaDB importer
- upsert courses and users from Canvas SIS CSVs
- sync enrollments table to match CSV exactly

## Testing
- `python -m py_compile scripts/import_to_sqlite.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a52d312514832282d28abe5c62d714