### PR TITLE
[FIX] Filter inactive Canvas users from attendance lists

### DIFF
--- a/bps_internal_tools/services/queries.py
+++ b/bps_internal_tools/services/queries.py
@@ -50,7 +50,7 @@ def get_courses_for_user(user_id: str, role: str | None = None, terms: list[str]
 
 def get_students_in_course(course_id: str) -> List[Dict]:
     """
-    Return students (Canvas users) in a given course_id (user_id + full_name).
+    Return active students (Canvas users) in a given course_id (user_id + full_name).
     """
     s = db.session
     stmt = (
@@ -58,6 +58,7 @@ def get_students_in_course(course_id: str) -> List[Dict]:
         .join(Enrollment, Enrollment.user_id == People.user_id)
         .where(Enrollment.course_id == course_id)
         .where(Enrollment.role == 'student')
+        .where(People.status == 'active')
         .order_by(People.full_name)
     )
     rows = s.execute(stmt).all()
@@ -111,7 +112,7 @@ def get_grade_section(section_id: int) -> Optional[Dict]:
     }
 
 def get_students_in_grade_section(section_id: int) -> List[Dict]:
-    """Return students for a given grade section."""
+    """Return active students for a given grade section."""
     info = get_grade_section(section_id)
     if not info or not info["reference_course_id"]:
         return []
@@ -122,6 +123,7 @@ def get_students_in_grade_section(section_id: int) -> List[Dict]:
         .join(Enrollment, Enrollment.user_id == People.user_id)
         .where(Enrollment.course_id == course_id)
         .where(Enrollment.role == 'student')
+        .where(People.status == 'active')
         .order_by(People.full_name)
     )
     rows = s.execute(stmt).all()


### PR DESCRIPTION
## Summary
- ensure attendance only includes Canvas users with active status
- document that only active students are returned from student lookup functions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abe4c0713c8322b5e9232ccbba4ba0