### PR TITLE
Add block selector to TOC attendance

### DIFF
--- a/bps_internal_tools/templates/select_course.html
+++ b/bps_internal_tools/templates/select_course.html
@@ -10,6 +10,14 @@
           <option value="{{ c.course_id }}">{{ c.short_name }} — {{ c.long_name }}</option>
         {% endfor %}
       </select>
+
+      <label for="block">Which block is this course in?</label>
+      <select id="block" name="block" required>
+        {% for i in range(1,7) %}
+          <option value="{{ i }}">Block {{ i }}</option>
+        {% endfor %}
+      </select>
+
       <button class="btn" type="submit">Continue to Attendance</button>
       <a class="btn secondary" href="{{ url_for('toc.index') }}">Back</a>
     </form>

--- a/bps_internal_tools/templates/take_attendance.html
+++ b/bps_internal_tools/templates/take_attendance.html
@@ -16,6 +16,7 @@
       <a class="btn" href="{{ url_for('toc.index') }}">Start Over</a>
     {% else %}
       <form method="post">
+        <input type="hidden" name="block" value="{{ block }}">
         <label>Select any students that are <b>ABSENT</b>.</label>
         <div class="grid">
           {% for s in students %}

--- a/bps_internal_tools/toc_attendance/routes.py
+++ b/bps_internal_tools/toc_attendance/routes.py
@@ -51,23 +51,32 @@ def search_teachers():
 def select_course(teacher_id):
     if request.method == "POST":
         course_id = request.form["course_id"]
-        return redirect(url_for("toc.take_attendance", course_id=course_id, teacher_id=teacher_id))
+        block = request.form["block"]
+        return redirect(
+            url_for(
+                "toc.take_attendance", course_id=course_id, teacher_id=teacher_id, block=block
+            )
+        )
     courses = get_courses_for_user(teacher_id, role="teacher", terms=DEFAULT_TERMS)
-    return render_template("select_course.html",
-                           courses=courses,
-                           teacher_id=teacher_id,
-                           page_title="TOC Attendance",
-                           page_subtitle="Simple attendance form for senior school coverage.",
-                           active_tool="TOC Attendance")
+    return render_template(
+        "select_course.html",
+        courses=courses,
+        teacher_id=teacher_id,
+        page_title="TOC Attendance",
+        page_subtitle="Simple attendance form for senior school coverage.",
+        active_tool="TOC Attendance",
+    )
 
 @toc_bp.route("/take_attendance/<course_id>", methods=["GET","POST"])
 @login_required
 @tool_required(TOOL_SLUG)
 def take_attendance(course_id):
+    block = request.args.get("block") if request.method == "GET" else request.form.get("block")
     students = get_students_in_course(course_id)
-    info = get_course_info(course_id) # returns {'short_name':..., 'long_name':...}
-    course_name = info.get("long_name") or info.get("short_name") or "Unknown Course"
-    teacher_id = request.args.get("teacher_id") # passed via redirect above
+    info = get_course_info(course_id)  # returns {'short_name':..., 'long_name':...}
+    base_course_name = info.get("long_name") or info.get("short_name") or "Unknown Course"
+    course_name = f"Block {block} - {base_course_name}" if block else base_course_name
+    teacher_id = request.args.get("teacher_id")  # passed via redirect above
     teachers = [t["full_name"] for t in get_teachers_in_course(course_id)]
 
     if request.method == "POST":
@@ -75,23 +84,29 @@ def take_attendance(course_id):
         absent_students = [s for s in students if str(s["user_id"]) in absent_ids]
         submitter = current_user().get("display_name") or current_user().get("username")
         log_attendance(absent_students, course_name, teachers, submitted_by=submitter)
-        return render_template("take_attendance.html",
-                               students=students,
-                               submitted=True,
-                               absent_ids=absent_ids,
-                               course_name=course_name,
-                               teacher_id=teacher_id,
-                               page_title="TOC Attendance",
-                               page_subtitle="Simple attendance form for senior school coverage.",
-                               active_tool="TOC Attendance")
-    return render_template("take_attendance.html",
-                           students=students,
-                           submitted=False,
-                           course_name=course_name,
-                           teacher_id=teacher_id,
-                           page_title="TOC Attendance",
-                           page_subtitle="Simple attendance form for senior school coverage.",
-                           active_tool="TOC Attendance")
+        return render_template(
+            "take_attendance.html",
+            students=students,
+            submitted=True,
+            absent_ids=absent_ids,
+            course_name=course_name,
+            teacher_id=teacher_id,
+            block=block,
+            page_title="TOC Attendance",
+            page_subtitle="Simple attendance form for senior school coverage.",
+            active_tool="TOC Attendance",
+        )
+    return render_template(
+        "take_attendance.html",
+        students=students,
+        submitted=False,
+        course_name=course_name,
+        teacher_id=teacher_id,
+        block=block,
+        page_title="TOC Attendance",
+        page_subtitle="Simple attendance form for senior school coverage.",
+        active_tool="TOC Attendance",
+    )
 
 @toc_bp.route("/grade/<int:grade_section_id>", methods=["GET", "POST"])
 @login_required


### PR DESCRIPTION
## Summary
- add block dropdown to course selection for TOC attendance
- propagate selected block to attendance form and logs

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abee4c12b48322a9dc51b19ac555cb