### PR TITLE
[FEATURE] ask for coverage block when picking a grade

### DIFF
--- a/bps_internal_tools/templates/index.html
+++ b/bps_internal_tools/templates/index.html
@@ -2,16 +2,22 @@
 {% block title %}Select Teacher · TOC Attendance{% endblock %}
 {% block content %}
   <div class="card">
-    <label>Select a grade</label>
-    <div class="grid">
-      {% for g in grade_sections %}
-        <a class="btn" href="{{ url_for('toc.take_attendance_grade', grade_section_id=g.id) }}">{{ g.display_name }}</a>
-      {% endfor %}
-    </div>
+    <label for="gradeSelect">Covering a grade?</label>
+    <form id="gradeForm">
+      <select id="gradeSelect" required>
+        <option value="" disabled selected>Select a grade…</option>
+        {% for g in grade_sections %}
+          <option value="{{ g.id }}">{{ g.display_name }}</option>
+        {% endfor %}
+      </select>
+      <button class="btn" type="submit">Continue</button>
+    </form>
   </div>
 
+  <div style="text-align:center; margin:20px 0; color: var(--muted); font-weight:700;">OR</div>
+
   <div class="card">
-    <label for="q">Search for the teacher you’re covering</label>
+    <label for="q">Or search for the teacher you’re covering</label>
     <div class="ac-wrap">
       <input id="q" class="input" type="text" placeholder="Start typing a name…" autocomplete="off" aria-autocomplete="list" aria-controls="ac" aria-expanded="false">
       <div id="ac" class="ac-list" role="listbox"></div>
@@ -23,13 +29,20 @@
 {% block scripts %}
 <script src="{{ url_for('static', filename='app.js') }}"></script>
 <script>
+  document.getElementById('gradeForm').addEventListener('submit', function(e) {
+    e.preventDefault();
+    const gradeId = document.getElementById('gradeSelect').value;
+    if (gradeId) {
+      window.location.href = "{{ url_for('toc.take_attendance_grade', grade_section_id=0) }}".replace('/0', '/' + encodeURIComponent(gradeId));
+    }
+  });
   setupTeacherSearch({
     inputId: 'q',
     listId: 'ac',
     clearId: 'clearBtn',
     searchUrl: '{{ url_for("toc.search_teachers") }}',
     onPick: (teacher) => {
-      window.location.href = "{{ url_for('toc.select_course', teacher_id='__ID__') }}".replace('__ID__', encodeURIComponent(teacher.id));
+      window.location.href = "{{ url_for('toc.select_course', teacher_id=0) }}".replace('/0', '/' + encodeURIComponent(teacher.id));
     }
   });
 </script>

--- a/bps_internal_tools/templates/select_block.html
+++ b/bps_internal_tools/templates/select_block.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Select Block · TOC Attendance{% endblock %}
+{% block content %}
+  <div class="card">
+    <div class="meta">Grade: <strong>{{ grade_section.display_name }}</strong></div>
+    <label for="block">Which block are you covering?</label>
+    <form method="post">
+      <select id="block" name="block" required>
+        {% for i in range(1,7) %}
+          <option value="{{ i }}">Block {{ i }}</option>
+        {% endfor %}
+      </select>
+      <button class="btn" type="submit">Continue to Attendance</button>
+      <a class="btn secondary" href="{{ url_for('toc.index') }}">Back</a>
+    </form>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Added block selection logic for grade-based attendance, prompting for a block unless the selected grade section is marked as “junior_school,” and included the block in the course name when logging attendance
- Introduced a dedicated page for picking the block to cover a grade, styled consistently with existing forms
- Redesigned the TOC index with a dropdown grade picker, an “OR” separator, and clearer messaging that choosing a grade or searching for a teacher are alternate paths

## Testing
- ✅ python -m py_compile bps_internal_tools/toc_attendance/routes.py
- ⚠️ pytest -q (no tests found)