### PR TITLE
[FEATURE] Grade_Section reference to Canvas Section or Course

### DIFF
--- a/bps_internal_tools/admin/routes.py
+++ b/bps_internal_tools/admin/routes.py
@@ -146,12 +146,14 @@ def create_grade_section_route():
     display_name = (request.form.get("display_name") or "").strip()
     school_level = (request.form.get("school_level") or "").strip()
     reference_course_id = (request.form.get("reference_course_id") or "").strip()
+    reference_is_section = bool(request.form.get("reference_is_section"))
     if not display_name:
         flash("Display name is required", "error"); return redirect(url_for("admin.grade_sections_page"))
     section = GradeSection(
         display_name=display_name,
         school_level=school_level or None,
         reference_course_id=reference_course_id or None,
+        reference_is_section=reference_is_section,
     )
     db.session.add(section)
     db.session.commit()
@@ -166,6 +168,7 @@ def update_grade_section_route(section_id):
     section.display_name = (request.form.get("display_name") or "").strip()
     section.school_level = (request.form.get("school_level") or "").strip() or None
     section.reference_course_id = (request.form.get("reference_course_id") or "").strip() or None
+    section.reference_is_section = bool(request.form.get("reference_is_section"))
     db.session.commit()
     flash(f"Grade section '{section.display_name}' updated", "ok")
     return redirect(url_for("admin.grade_sections_page"))

--- a/bps_internal_tools/models.py
+++ b/bps_internal_tools/models.py
@@ -100,6 +100,7 @@ class GradeSection(db.Model):
     display_name = Column(String(255), unique=True, nullable=False)
     school_level = Column(String(64))
     reference_course_id = Column(String(32), ForeignKey("courses.course_id", ondelete="SET NULL"))
+    reference_is_section = Column(Boolean, default=False, nullable=False)
 
 
 # ------ For MySchool Import --------

--- a/bps_internal_tools/templates/admin_grade_sections.html
+++ b/bps_internal_tools/templates/admin_grade_sections.html
@@ -13,6 +13,11 @@
     <label>Reference Course ID</label>
     <input class="input" name="reference_course_id" placeholder="c123456">
 
+    <label style="display:flex; align-items:center; margin-top:8px;">
+      <input type="checkbox" name="reference_is_section" style="margin-right:4px;">
+      Reference ID is Canvas Section
+    </label>
+
     <button class="btn" type="submit">Create Grade Section</button>
   </form>
 </div>
@@ -25,6 +30,7 @@
         <th>Display Name</th>
         <th>School Level</th>
         <th>Reference Course ID</th>
+        <th>Is Section?</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -35,6 +41,7 @@
         <td><input class="input" name="display_name" value="{{ s.display_name }}"></td>
         <td><input class="input" name="school_level" value="{{ s.school_level or '' }}"></td>
         <td><input class="input" name="reference_course_id" value="{{ s.reference_course_id or '' }}"></td>
+        <td style="text-align:center;"><input type="checkbox" name="reference_is_section" {% if s.reference_is_section %}checked{% endif %}></td>
         <td>
           <div class="row">
             <button class="btn" type="submit">Save</button>

--- a/migrations/versions/4b5a4cc6e987_grade_sections_add_reference_is_section.py
+++ b/migrations/versions/4b5a4cc6e987_grade_sections_add_reference_is_section.py
@@ -1,0 +1,33 @@
+"""add reference_is_section flag to grade_sections
+
+Revision ID: 4b5a4cc6e987
+Revises: 3b5f9b8b2c6d
+Create Date: 2025-03-10 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "4b5a4cc6e987"
+down_revision = "3b5f9b8b2c6d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("grade_sections") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "reference_is_section",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+        batch_op.alter_column("reference_is_section", server_default=None)
+
+
+def downgrade():
+    with op.batch_alter_table("grade_sections") as batch_op:
+        batch_op.drop_column("reference_is_section")


### PR DESCRIPTION
## Summary
- Enabled Grade Sections to treat the stored reference ID as either a course or Canvas section by adding a boolean flag to the model and database schema
- Updated admin routes and templates with a checkbox so users can specify when a Grade Section references a Canvas section, ensuring the flag is saved on create and update
- Adjusted grade section queries to honor the new flag, pulling student enrollments by course or section accordingly