### PR TITLE
[FIX] Remove foreign key constraint on reference course in grad section

### DIFF
--- a/bps_internal_tools/models.py
+++ b/bps_internal_tools/models.py
@@ -99,7 +99,9 @@ class GradeSection(db.Model):
     id = Column(Integer, primary_key=True, autoincrement=True)
     display_name = Column(String(255), unique=True, nullable=False)
     school_level = Column(String(64))
-    reference_course_id = Column(String(32), ForeignKey("courses.course_id", ondelete="SET NULL"))
+    # Can reference either a Canvas course ID or section ID; no FK constraint so
+    # sections without a backing course row can be stored
+    reference_course_id = Column(String(32))
     reference_is_section = Column(Boolean, default=False, nullable=False)
 
 

--- a/migrations/versions/1e712630f869_grade_sections_drop_reference_course_fk.py
+++ b/migrations/versions/1e712630f869_grade_sections_drop_reference_course_fk.py
@@ -1,0 +1,31 @@
+"""remove foreign key constraint on grade_sections.reference_course_id
+
+Revision ID: 1e712630f869
+Revises: 4b5a4cc6e987
+Create Date: 2025-04-20 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "1e712630f869"
+down_revision = "4b5a4cc6e987"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("grade_sections") as batch_op:
+        batch_op.drop_constraint("grade_sections_ibfk_1", type_="foreignkey")
+
+
+def downgrade():
+    with op.batch_alter_table("grade_sections") as batch_op:
+        batch_op.create_foreign_key(
+            "grade_sections_ibfk_1",
+            "courses",
+            ["reference_course_id"],
+            ["course_id"],
+            ondelete="SET NULL",
+        )


### PR DESCRIPTION
## Summary

Remove the foreign key constraint for the `grade_section` object so that Canvas section id's can be used instead of just course ids. This is needed to make the new feature where a `grade_section` can reference either a course or a section in Canvas data to use as its student cohort.